### PR TITLE
cv-region: readme: fix bad link to documentation

### DIFF
--- a/rtsf-at-checkout-cv-region-of-interest/README.md
+++ b/rtsf-at-checkout-cv-region-of-interest/README.md
@@ -4,4 +4,4 @@ CV Region of Interest is part of the *Real Time Sensor Fusion for Loss Detection
 
 Please refer to the following link for complete documentation of the *Real Time Sensor Fusion for Loss Detection at Checkout Reference Design*
 
-https://pages.github.com/intel-iot-devkit/rtsf-at-checkout-reference-design/
+https://intel-iot-devkit.github.io/rtsf-at-checkout-reference-design/


### PR DESCRIPTION
The pages.github link yields 404 error. Update to use same link
as the main directory readme which is github.io, assuming that
was the intended content based on same text description in both.

Signed-off-by: Jennifer Williams <jennifer.m.williams@intel.com>